### PR TITLE
Add interactive quest planner with adaptive progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It’s built with **Next.js**, deployable on **Vercel**, and designed to be fast
 ## 🚀 Features
 
 - **Daily quests**: smartly chosen mix of random, goal-biased, enjoyment-weighted, and corrective exercises
+- **Interactive quest builder**: adjust daily check-in sliders to see the plan adapt in real-time
 - **Adaptive progression**: per-exercise scaling using rolling averages of difficulty (RPE), capped for safety
 - **Rep scheme variety**: rotates low-rep/high-weight, mid, and high-rep/low-weight schemes
 - **Daily check-in**: “How are you feeling today?” input to bias quest difficulty and skip sore muscles
@@ -47,7 +48,8 @@ It’s built with **Next.js**, deployable on **Vercel**, and designed to be fast
 
 - `requirements.md` → Detailed functional spec  
 - `quest_config.ts` → Configurable progression settings  
-- `muscle_map.json` (future) → Primary muscles per exercise for corrective logic  
+- `muscle_map.json` (future) → Primary muscles per exercise for corrective logic
+- `lib/sample-data.ts` → Demo training history + default check-in used by the quest builder
 
 ---
 

--- a/app/components/DataShowcase.tsx
+++ b/app/components/DataShowcase.tsx
@@ -1,4 +1,4 @@
-import type { Exercise, MuscleMap } from '@/lib/data-loader';
+import type { Exercise, MuscleMap } from '@/lib/domain-types';
 
 type DataShowcaseProps = {
   exercises: Exercise[];

--- a/app/components/QuestPlanner.tsx
+++ b/app/components/QuestPlanner.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type {
+  DailyCheckIn,
+  Exercise,
+  MuscleMap,
+  QuestConfig,
+  QuestPlan,
+  UserProfile,
+  WorkoutLog
+} from '@/lib/domain-types';
+import { generateQuestPlan } from '@/lib/quest-engine';
+
+const feelingOptions: Array<{ label: string; value: DailyCheckIn['overallFeeling']; description: string }> = [
+  { label: 'Easy day', value: 'easy', description: 'Feeling energetic and ready to push.' },
+  { label: 'Steady day', value: 'normal', description: 'Baseline energy and recovery.' },
+  { label: 'Hard day', value: 'hard', description: 'Tired, stressed, or still recovering.' }
+];
+
+const buildMuscleOptions = (muscleMap: MuscleMap) => {
+  const muscles = new Set<string>();
+
+  Object.values(muscleMap).forEach((entry) => {
+    entry.primary.forEach((muscle) => muscles.add(muscle));
+    entry.synergists.forEach((muscle) => muscles.add(muscle));
+  });
+
+  return Array.from(muscles).sort((a, b) => a.localeCompare(b));
+};
+
+const formatSummary = (plan: QuestPlan) => {
+  const feelingLabel = feelingOptions.find((option) => option.value === plan.summary.feeling)?.label ?? 'Steady day';
+  const sorenessLabel = plan.summary.soreMuscles.length > 0
+    ? plan.summary.soreMuscles.map((muscle) => muscle.replaceAll('_', ' ')).join(', ')
+    : 'None';
+
+  return `${feelingLabel} · Sore: ${sorenessLabel}`;
+};
+
+const QuestPlanner = ({
+  exercises,
+  muscleMap,
+  logs,
+  config,
+  userProfile,
+  initialCheckIn
+}: {
+  exercises: Exercise[];
+  muscleMap: MuscleMap;
+  logs: WorkoutLog[];
+  config: QuestConfig;
+  userProfile: UserProfile;
+  initialCheckIn: DailyCheckIn;
+}) => {
+  const muscleOptions = useMemo(() => buildMuscleOptions(muscleMap), [muscleMap]);
+  const [checkIn, setCheckIn] = useState<DailyCheckIn>(initialCheckIn);
+
+  const questPlan = useMemo(
+    () =>
+      generateQuestPlan({
+        exercises,
+        muscleMap,
+        logs,
+        checkIn,
+        userProfile,
+        config
+      }),
+    [checkIn, config, exercises, logs, muscleMap, userProfile]
+  );
+
+  const handleFeelingChange = (value: DailyCheckIn['overallFeeling']) => {
+    setCheckIn((previous) => ({ ...previous, overallFeeling: value }));
+  };
+
+  const toggleSoreMuscle = (muscle: string) => {
+    setCheckIn((previous) => {
+      const isSelected = previous.soreMuscles.includes(muscle);
+      const soreMuscles = isSelected
+        ? previous.soreMuscles.filter((item) => item !== muscle)
+        : [...previous.soreMuscles, muscle];
+
+      return { ...previous, soreMuscles };
+    });
+  };
+
+  const clearSoreness = () => {
+    setCheckIn((previous) => ({ ...previous, soreMuscles: [] }));
+  };
+
+  const questItems = questPlan.recommendations.map((recommendation) => {
+    const noteItems = recommendation.notes.map((note, index) => (
+      <li key={`${recommendation.exerciseId}-note-${index}`}>{note}</li>
+    ));
+
+    return (
+      <article key={recommendation.exerciseId} className="quest-card">
+        <header>
+          <h3>{recommendation.exerciseLabel}</h3>
+          <p>{recommendation.focus}</p>
+        </header>
+        <dl>
+          <div>
+            <dt>Rep scheme</dt>
+            <dd>{recommendation.repScheme}</dd>
+          </div>
+          <div>
+            <dt>Prescription</dt>
+            <dd>
+              {recommendation.sets} sets · {recommendation.reps} reps · {recommendation.targetLoad}
+            </dd>
+          </div>
+        </dl>
+        <footer>
+          <span>Notes</span>
+          <ul>{noteItems}</ul>
+        </footer>
+      </article>
+    );
+  });
+
+  const sorenessChips = muscleOptions.map((muscle) => {
+    const checked = checkIn.soreMuscles.includes(muscle);
+
+    return (
+      <label key={muscle} className={`chip ${checked ? 'chip--active' : ''}`}>
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={() => toggleSoreMuscle(muscle)}
+          aria-label={muscle.replaceAll('_', ' ')}
+        />
+        <span>{muscle.replaceAll('_', ' ')}</span>
+      </label>
+    );
+  });
+
+  const feelingChoices = feelingOptions.map((option) => (
+    <label key={option.value} className={`choice ${checkIn.overallFeeling === option.value ? 'choice--active' : ''}`}>
+      <input
+        type="radio"
+        name="overallFeeling"
+        value={option.value}
+        checked={checkIn.overallFeeling === option.value}
+        onChange={() => handleFeelingChange(option.value)}
+      />
+      <div>
+        <strong>{option.label}</strong>
+        <p>{option.description}</p>
+      </div>
+    </label>
+  ));
+
+  return (
+    <section aria-labelledby="quest-planner-title">
+      <h2 id="quest-planner-title">Daily quest builder</h2>
+      <p>
+        Update how you feel today and QuestFit will adapt the prescription, dialing exercises up or down
+        while respecting recovery.
+      </p>
+      <div className="grid two-column">
+        <div className="control-panel">
+          <h3>Daily check-in</h3>
+          <fieldset>
+            <legend>How are you feeling?</legend>
+            <div className="choice-grid">{feelingChoices}</div>
+          </fieldset>
+          <fieldset>
+            <legend>Sore or sensitive muscles</legend>
+            <div className="chip-grid">{sorenessChips}</div>
+            <button type="button" onClick={clearSoreness} className="link-button">
+              Clear selections
+            </button>
+          </fieldset>
+        </div>
+        <div className="quest-results">
+          <header>
+            <h3>Today&apos;s quest</h3>
+            <span className="badge subtle">{formatSummary(questPlan)}</span>
+          </header>
+          <div className="quest-grid">{questItems}</div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default QuestPlanner;

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,6 +99,11 @@ dd {
   letter-spacing: 0.02em;
 }
 
+.badge.subtle {
+  background: rgba(148, 163, 184, 0.15);
+  color: rgba(226, 232, 240, 0.8);
+}
+
 .code-block {
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 0.85rem;
@@ -123,6 +128,171 @@ dd {
   border-radius: 0.75rem;
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin: 0;
+}
+
+legend {
+  font-weight: 600;
+  padding: 0 0.5rem;
+}
+
+.choice-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.choice {
+  position: relative;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.5);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.choice input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.choice strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.choice p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.choice--active {
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  transition: border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.chip input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.chip--active {
+  border-color: rgba(56, 189, 248, 0.7);
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.link-button {
+  appearance: none;
+  background: none;
+  border: none;
+  color: rgba(148, 197, 255, 0.9);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.quest-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.quest-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.quest-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.quest-card header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.quest-card dl {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.quest-card dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.quest-card dt {
+  margin: 0;
+  font-weight: 600;
+}
+
+.quest-card dd {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.quest-card footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quest-card footer span {
+  font-weight: 600;
+}
+
+.quest-card footer ul {
+  margin: 0;
+  padding-left: 1.25rem;
 }
 
 footer {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,11 @@ import DataShowcase from '@/app/components/DataShowcase';
 import DesignPrinciples from '@/app/components/DesignPrinciples';
 import FeatureGrid from '@/app/components/FeatureGrid';
 import IntroHero from '@/app/components/IntroHero';
+import QuestPlanner from '@/app/components/QuestPlanner';
 import WorkflowTimeline from '@/app/components/WorkflowTimeline';
 import { loadExerciseList, loadMuscleMap, loadQuestConfigExcerpt } from '@/lib/data-loader';
+import { questConfig } from '@/lib/quest-config';
+import { defaultDailyCheckIn, sampleLogs, sampleUserProfile } from '@/lib/sample-data';
 
 const HomePage = async () => {
   const [exercises, muscleMap, configSnippet] = await Promise.all([
@@ -17,6 +20,14 @@ const HomePage = async () => {
       <IntroHero />
       <FeatureGrid />
       <WorkflowTimeline />
+      <QuestPlanner
+        exercises={exercises}
+        muscleMap={muscleMap}
+        logs={sampleLogs}
+        config={questConfig}
+        userProfile={sampleUserProfile}
+        initialCheckIn={defaultDailyCheckIn}
+      />
       <DataShowcase
         exercises={exercises}
         muscleMap={muscleMap}

--- a/lib/data-loader.ts
+++ b/lib/data-loader.ts
@@ -1,18 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
-export type Exercise = {
-  id: string;
-  label: string;
-};
-
-export type MuscleMap = Record<
-  string,
-  {
-    primary: string[];
-    synergists: string[];
-  }
->;
+import type { Exercise, MuscleMap } from './domain-types';
 
 const resolveDataPath = (fileName: string) =>
   path.join(process.cwd(), 'data', fileName);

--- a/lib/domain-types.ts
+++ b/lib/domain-types.ts
@@ -1,0 +1,71 @@
+export type Exercise = {
+  id: string;
+  label: string;
+};
+
+export type MuscleMapEntry = {
+  primary: string[];
+  synergists: string[];
+};
+
+export type MuscleMap = Record<string, MuscleMapEntry>;
+
+export type WorkoutLog = {
+  exerciseId: string;
+  date: string; // ISO date string
+  sets: number;
+  reps: number;
+  weight: number | null;
+  difficulty: number; // RPE 1-10
+  enjoyment: number; // 1-5
+  feltIn: string[];
+  notes?: string;
+};
+
+export type DailyCheckIn = {
+  date: string;
+  overallFeeling: 'easy' | 'normal' | 'hard';
+  soreMuscles: string[];
+  notes?: string;
+};
+
+export type UserProfile = {
+  goals: string[];
+  preferredQuestSize: number;
+};
+
+export type QuestConfig = {
+  smoothingWindow: number;
+  enjoymentBiasWeight: number;
+  difficultyTarget: number;
+  maxIncreaseStep: number;
+  maxDecreaseStep: number;
+  sorenessScalingFactor: number;
+  cooldownDaysPerMuscle: number;
+  deloadAfterDaysMissed: number;
+  repSchemeOptions: Array<{
+    label: string;
+    reps: [number, number];
+    intensity: 'high' | 'moderate' | 'low';
+  }>;
+};
+
+export type QuestRecommendation = {
+  exerciseId: string;
+  exerciseLabel: string;
+  focus: string;
+  sets: number;
+  reps: number;
+  targetLoad: string;
+  repScheme: string;
+  notes: string[];
+};
+
+export type QuestPlan = {
+  generatedAt: string;
+  summary: {
+    feeling: DailyCheckIn['overallFeeling'];
+    soreMuscles: string[];
+  };
+  recommendations: QuestRecommendation[];
+};

--- a/lib/quest-config.ts
+++ b/lib/quest-config.ts
@@ -1,0 +1,17 @@
+import type { QuestConfig as QuestConfigShape } from './domain-types';
+
+export const questConfig: QuestConfigShape = {
+  smoothingWindow: 5,
+  enjoymentBiasWeight: 1.5,
+  difficultyTarget: 7,
+  maxIncreaseStep: 0.2,
+  maxDecreaseStep: 0.15,
+  sorenessScalingFactor: 0.5,
+  cooldownDaysPerMuscle: 2,
+  deloadAfterDaysMissed: 5,
+  repSchemeOptions: [
+    { label: 'Low Rep', reps: [3, 5], intensity: 'high' },
+    { label: 'Mid Rep', reps: [6, 10], intensity: 'moderate' },
+    { label: 'High Rep', reps: [12, 20], intensity: 'low' }
+  ]
+};

--- a/lib/quest-engine.ts
+++ b/lib/quest-engine.ts
@@ -1,0 +1,285 @@
+import type {
+  DailyCheckIn,
+  Exercise,
+  MuscleMap,
+  QuestPlan,
+  QuestRecommendation,
+  QuestConfig,
+  UserProfile,
+  WorkoutLog
+} from './domain-types';
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+const parseDate = (value: string) => new Date(`${value}T00:00:00Z`);
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const daysBetween = (later: string, earlier: string) => {
+  const laterDate = parseDate(later);
+  const earlierDate = parseDate(earlier);
+  const diff = laterDate.getTime() - earlierDate.getTime();
+  return Math.floor(diff / MILLISECONDS_PER_DAY);
+};
+
+const average = (values: number[]) => {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+};
+
+const groupLogsByExercise = (logs: WorkoutLog[]) => {
+  const grouped = new Map<string, WorkoutLog[]>();
+
+  logs.forEach((log) => {
+    const exerciseLogs = grouped.get(log.exerciseId) ?? [];
+    exerciseLogs.push(log);
+    grouped.set(log.exerciseId, exerciseLogs);
+  });
+
+  grouped.forEach((exerciseLogs, key) => {
+    const sortedLogs = [...exerciseLogs].sort((a, b) =>
+      a.date > b.date ? -1 : a.date < b.date ? 1 : 0
+    );
+    grouped.set(key, sortedLogs);
+  });
+
+  return grouped;
+};
+
+const enjoymentBias = (enjoyment: number, config: QuestConfig) => {
+  const centredEnjoyment = enjoyment - 3; // 3 is neutral on a 1-5 scale
+  const scaled = (centredEnjoyment / 2) * (config.enjoymentBiasWeight / 2);
+  return 1 + scaled;
+};
+
+const recencyBoost = (daysSince: number | null, cooldownDays: number) => {
+  if (daysSince === null) {
+    return 1.1; // unseen exercises get a gentle boost
+  }
+
+  if (daysSince <= cooldownDays) {
+    return 0.25;
+  }
+
+  const normalised = clamp(daysSince / 7, 0, 1);
+  return 1 + normalised * 0.3;
+};
+
+const sorenessPenalty = (targetMuscles: string[], soreMuscles: string[], scale: number) => {
+  const intersects = targetMuscles.some((muscle) => soreMuscles.includes(muscle));
+  return intersects ? scale : 1;
+};
+
+const pickRepScheme = (index: number, config: QuestConfig) => {
+  const scheme = config.repSchemeOptions[index % config.repSchemeOptions.length];
+  const midpoint = Math.round((scheme.reps[0] + scheme.reps[1]) / 2);
+  const sets = scheme.intensity === 'high' ? 5 : scheme.intensity === 'moderate' ? 4 : 3;
+
+  return {
+    schemeLabel: `${scheme.label} · ${scheme.reps[0]}-${scheme.reps[1]} reps`,
+    reps: midpoint,
+    sets
+  };
+};
+
+const applyProgression = ({
+  history,
+  config,
+  overallFeeling,
+  isSore,
+  daysSince
+}: {
+  history: WorkoutLog[];
+  config: QuestConfig;
+  overallFeeling: DailyCheckIn['overallFeeling'];
+  isSore: boolean;
+  daysSince: number | null;
+}) => {
+  const recent = history.slice(0, config.smoothingWindow);
+  const averageDifficulty = average(recent.map((log) => log.difficulty));
+  const latest = recent[0];
+
+  if (!latest) {
+    return { targetLoad: 'Intro session', suggestedSets: 3, suggestedReps: 8 };
+  }
+
+  const baselineLoad = latest.weight ?? 0;
+  const isTimedHold = latest.weight === null;
+  const isBodyweight = latest.weight === 0;
+  const repGuess = Math.round(average(recent.map((log) => log.reps)) || latest.reps);
+  const setGuess = Math.round(average(recent.map((log) => log.sets)) || latest.sets);
+
+  const difficultyDelta = config.difficultyTarget - averageDifficulty;
+  const adjustmentLimit = difficultyDelta > 0 ? config.maxIncreaseStep : config.maxDecreaseStep;
+  const rawAdjustment = clamp(Math.abs(difficultyDelta) / 5, 0, adjustmentLimit);
+  const direction = difficultyDelta >= 0 ? 1 : -1;
+
+  const deloadCandidate = typeof daysSince === 'number' && daysSince > config.deloadAfterDaysMissed;
+  let intensityModifier = 1 + direction * rawAdjustment;
+
+  if (overallFeeling === 'hard') {
+    intensityModifier *= 0.9;
+  }
+
+  if (overallFeeling === 'easy') {
+    intensityModifier *= 1.05;
+  }
+
+  if (isSore) {
+    intensityModifier *= config.sorenessScalingFactor;
+  }
+
+  if (deloadCandidate) {
+    intensityModifier *= 0.9;
+  }
+
+  if (isTimedHold) {
+    const adjustedSeconds = Math.max(10, Math.round(repGuess * intensityModifier));
+    return {
+      targetLoad: `${adjustedSeconds} sec hold`,
+      suggestedSets: setGuess,
+      suggestedReps: repGuess
+    };
+  }
+
+  let adjustedLoad = baselineLoad;
+
+  if (!isBodyweight && !isTimedHold && baselineLoad > 0) {
+    adjustedLoad = baselineLoad * intensityModifier;
+  }
+
+  const bodyweightSuggestion = direction > 0
+    ? 'Bodyweight + light band'
+    : 'Bodyweight focus on tempo';
+
+  const roundedLoad = !isBodyweight && baselineLoad > 0
+    ? `${Math.round(adjustedLoad / 2.5) * 2.5} kg`
+    : bodyweightSuggestion;
+
+  return {
+    targetLoad: roundedLoad,
+    suggestedSets: setGuess,
+    suggestedReps: repGuess
+  };
+};
+
+const collectNotes = ({
+  latest,
+  muscleMapEntry,
+  isSore
+}: {
+  latest: WorkoutLog | undefined;
+  muscleMapEntry: MuscleMap[string];
+  isSore: boolean;
+}) => {
+  const notes: string[] = [];
+
+  if (latest?.notes) {
+    notes.push(`Last time: ${latest.notes}`);
+  }
+
+  const feltMisfire = latest?.feltIn.some((muscle) => !muscleMapEntry.primary.includes(muscle)) ?? false;
+
+  if (feltMisfire) {
+    notes.push('Add light activation for support muscles before sets.');
+  }
+
+  if (isSore) {
+    notes.push('Dial effort back because these muscles are sore.');
+  }
+
+  if (notes.length === 0) {
+    notes.push('Focus on crisp technique and controlled tempo.');
+  }
+
+  return notes;
+};
+
+export const generateQuestPlan = ({
+  exercises,
+  muscleMap,
+  logs,
+  checkIn,
+  userProfile,
+  config
+}: {
+  exercises: Exercise[];
+  muscleMap: MuscleMap;
+  logs: WorkoutLog[];
+  checkIn: DailyCheckIn;
+  userProfile: UserProfile;
+  config: QuestConfig;
+}): QuestPlan => {
+  const logsByExercise = groupLogsByExercise(logs);
+  const scored: Array<{ recommendation: QuestRecommendation; score: number }> = [];
+
+  exercises.forEach((exercise, index) => {
+    const mapEntry = muscleMap[exercise.id];
+
+    if (!mapEntry) {
+      return;
+    }
+
+    const history = logsByExercise.get(exercise.id) ?? [];
+    const averageEnjoyment = average(history.map((log) => log.enjoyment)) || 3;
+    const primaryTargets = mapEntry.primary;
+    const sorePenalty = sorenessPenalty(primaryTargets, checkIn.soreMuscles, config.sorenessScalingFactor);
+    const lastLog = history[0];
+    const daysSince = lastLog ? daysBetween(checkIn.date, lastLog.date) : null;
+    const repPlan = pickRepScheme(index, config);
+    const progression = applyProgression({
+      history,
+      config,
+      overallFeeling: checkIn.overallFeeling,
+      isSore: sorePenalty < 1,
+      daysSince
+    });
+
+    const goalOverlap = primaryTargets.filter((muscle) => userProfile.goals.includes(muscle)).length;
+    const goalBoost = 1 + goalOverlap * 0.25;
+    const recency = recencyBoost(daysSince, config.cooldownDaysPerMuscle);
+    const enjoyment = enjoymentBias(averageEnjoyment, config);
+    const feelingFactor = checkIn.overallFeeling === 'easy' ? 1.05 : checkIn.overallFeeling === 'hard' ? 0.9 : 1;
+    const score = goalBoost * recency * enjoyment * sorePenalty * feelingFactor;
+    const focus = `Primary: ${primaryTargets.join(', ')}${mapEntry.synergists.length ? ` · Support: ${mapEntry.synergists.join(', ')}` : ''}`;
+    const notes = collectNotes({
+      latest: lastLog,
+      muscleMapEntry: mapEntry,
+      isSore: sorePenalty < 1
+    });
+
+    const recommendation: QuestRecommendation = {
+      exerciseId: exercise.id,
+      exerciseLabel: exercise.label,
+      focus,
+      sets: repPlan.sets ?? progression.suggestedSets,
+      reps: repPlan.reps ?? progression.suggestedReps,
+      targetLoad: progression.targetLoad,
+      repScheme: repPlan.schemeLabel,
+      notes
+    };
+
+    scored.push({ recommendation, score });
+  });
+
+  const sortedRecommendations = scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, userProfile.preferredQuestSize)
+    .map((entry) => entry.recommendation);
+
+  const plan: QuestPlan = {
+    generatedAt: checkIn.date,
+    summary: {
+      feeling: checkIn.overallFeeling,
+      soreMuscles: checkIn.soreMuscles
+    },
+    recommendations: sortedRecommendations
+  };
+
+  return plan;
+};

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,0 +1,181 @@
+import type { DailyCheckIn, UserProfile, WorkoutLog } from './domain-types';
+
+export const sampleUserProfile: UserProfile = {
+  goals: ['pectoralis_major', 'latissimus_dorsi', 'rectus_abdominis'],
+  preferredQuestSize: 5
+};
+
+export const defaultDailyCheckIn: DailyCheckIn = {
+  date: '2024-05-20',
+  overallFeeling: 'normal',
+  soreMuscles: ['hamstrings'],
+  notes: 'Hamstrings tight after long run.'
+};
+
+export const sampleLogs: WorkoutLog[] = [
+  {
+    exerciseId: 'bench_press',
+    date: '2024-05-18',
+    sets: 4,
+    reps: 6,
+    weight: 85,
+    difficulty: 8,
+    enjoyment: 4,
+    feltIn: ['pectoralis_major', 'triceps_brachii'],
+    notes: 'Last set grindy but solid bar path.'
+  },
+  {
+    exerciseId: 'bench_press',
+    date: '2024-05-11',
+    sets: 4,
+    reps: 6,
+    weight: 82.5,
+    difficulty: 7,
+    enjoyment: 4,
+    feltIn: ['pectoralis_major'],
+    notes: 'Felt smooth; ready for small bump.'
+  },
+  {
+    exerciseId: 'squat',
+    date: '2024-05-17',
+    sets: 5,
+    reps: 5,
+    weight: 110,
+    difficulty: 9,
+    enjoyment: 3,
+    feltIn: ['quadriceps', 'erector_spinae'],
+    notes: 'Back felt taxed, keep load steady.'
+  },
+  {
+    exerciseId: 'squat',
+    date: '2024-05-10',
+    sets: 5,
+    reps: 5,
+    weight: 107.5,
+    difficulty: 8,
+    enjoyment: 3,
+    feltIn: ['quadriceps'],
+    notes: 'Solid depth but knees caved a bit.'
+  },
+  {
+    exerciseId: 'deadlift',
+    date: '2024-05-14',
+    sets: 3,
+    reps: 5,
+    weight: 130,
+    difficulty: 8,
+    enjoyment: 3,
+    feltIn: ['hamstrings', 'erector_spinae'],
+    notes: 'Grip slipping on final set.'
+  },
+  {
+    exerciseId: 'deadlift',
+    date: '2024-05-07',
+    sets: 3,
+    reps: 5,
+    weight: 125,
+    difficulty: 7,
+    enjoyment: 3,
+    feltIn: ['hamstrings'],
+    notes: 'Moved quickly, grip solid.'
+  },
+  {
+    exerciseId: 'overhead_press',
+    date: '2024-05-16',
+    sets: 4,
+    reps: 5,
+    weight: 50,
+    difficulty: 7,
+    enjoyment: 4,
+    feltIn: ['anterior_deltoid', 'triceps_brachii'],
+    notes: 'Felt it in upper traps more than usual.'
+  },
+  {
+    exerciseId: 'overhead_press',
+    date: '2024-05-09',
+    sets: 4,
+    reps: 5,
+    weight: 47.5,
+    difficulty: 6,
+    enjoyment: 4,
+    feltIn: ['anterior_deltoid'],
+    notes: 'Great pop, ready to push.'
+  },
+  {
+    exerciseId: 'pull_up',
+    date: '2024-05-15',
+    sets: 4,
+    reps: 8,
+    weight: 0,
+    difficulty: 7,
+    enjoyment: 5,
+    feltIn: ['latissimus_dorsi', 'biceps_brachii'],
+    notes: 'Added slight pause at top.'
+  },
+  {
+    exerciseId: 'pull_up',
+    date: '2024-05-08',
+    sets: 4,
+    reps: 8,
+    weight: 0,
+    difficulty: 6,
+    enjoyment: 5,
+    feltIn: ['latissimus_dorsi'],
+    notes: 'Could add load next time.'
+  },
+  {
+    exerciseId: 'plank',
+    date: '2024-05-13',
+    sets: 3,
+    reps: 45,
+    weight: null,
+    difficulty: 6,
+    enjoyment: 4,
+    feltIn: ['rectus_abdominis', 'obliques'],
+    notes: 'Steady breathing, minor shaking.'
+  },
+  {
+    exerciseId: 'plank',
+    date: '2024-05-06',
+    sets: 3,
+    reps: 40,
+    weight: null,
+    difficulty: 5,
+    enjoyment: 4,
+    feltIn: ['rectus_abdominis'],
+    notes: 'Could extend duration slightly.'
+  },
+  {
+    exerciseId: 'barbell_row',
+    date: '2024-05-12',
+    sets: 4,
+    reps: 8,
+    weight: 70,
+    difficulty: 7,
+    enjoyment: 4,
+    feltIn: ['latissimus_dorsi', 'rhomboids'],
+    notes: 'Lower back tight by end.'
+  },
+  {
+    exerciseId: 'lunge',
+    date: '2024-05-11',
+    sets: 3,
+    reps: 10,
+    weight: 30,
+    difficulty: 6,
+    enjoyment: 3,
+    feltIn: ['quadriceps', 'gluteus_maximus'],
+    notes: 'Balance wobbly on left side.'
+  },
+  {
+    exerciseId: 'dip',
+    date: '2024-05-10',
+    sets: 3,
+    reps: 10,
+    weight: 0,
+    difficulty: 7,
+    enjoyment: 4,
+    feltIn: ['pectoralis_major', 'triceps_brachii'],
+    notes: 'Shoulders pinched slightly at bottom.'
+  }
+];


### PR DESCRIPTION
## Summary
- implement quest domain types, sample data, and config utilities powering the adaptive engine
- add a client-side QuestPlanner that reacts to daily check-ins and displays personalized prescriptions
- wire the planner into the homepage with updated styles and documentation for the new experience

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4b7e93d7083309a8934122b39172b